### PR TITLE
Simple fix to remove spacing in `Discord` link in the footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -69,7 +69,7 @@ module.exports = {
             },
             {
               label: 'Discord',
-              href: ' https://discord.gg/zv8C9F8',
+              href: 'https://discord.gg/zv8C9F8',
             },
             {
               label: 'Twitter',


### PR DESCRIPTION
Title is self-explanatory.

![issue at hand](https://cute.floofy.dev/images/34c92160.png)